### PR TITLE
Add outlinePath to template vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Example:
 }
 ```
 
+## Outline path prefix
+
+Setting node is `copyCodeAsMarkdown.outlinePrefix`. Default value is `"> &squ; "`
+
 ## Outline path delimiter
 
-Setting node is `copyCodeAsMarkdown.delimiter`. Default value is `" &raquo; "`
+Setting node is `copyCodeAsMarkdown.outlineDelimiter`. Default value is `" &raquo; "`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Here are some of the builtin templates:
   "default": "*{filename}* {lineNumber}:\n```{lang}\n{text}\n```",
   "lineRange": "*{filename}* {lineNumber} - {lineNumberEnd}:\n```{lang}\n{text}\n```",
   "onlyCode": "```{lang}\n{text}\n```",
-  "onlyPosition": "{filename}:{lineNumber}:{colNumber}"
+  "onlyPosition": "{filename}:{lineNumber}:{colNumber}",
+  "withOutline": "[{filename}#L{lineNumber}](/{filename}#L{lineNumber})\n>{outlinePath}\n```{lang}\n{text}\n```"
 }
 ```
 
@@ -66,6 +67,7 @@ Setting node is `copyCodeAsMarkdown.template`. Available vars:
 + `{colNumberEnd}`
 + `{lang}`
 + `{text}`
++ `{outlinePath}`
 
 Example:
 
@@ -74,3 +76,7 @@ Example:
     "copyCodeAsMarkdown.template": "```{lang}\n{text}\n```"
 }
 ```
+
+## Outline path delimiter
+
+Setting node is `copyCodeAsMarkdown.delimiter`. Default value is `" &raquo; "`

--- a/extension.js
+++ b/extension.js
@@ -1,9 +1,11 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
-const util = require('./util')
+const util = require('./util');
+const outline = require('./outline');
 
 const builtinTemplate = `*{fileName}* {lineNumber}:\n\`\`\`{lang}\n{text}\n\`\`\``;
+const builtinDelimiter = ' &raquo; ';
 
 
 /**
@@ -12,11 +14,7 @@ const builtinTemplate = `*{fileName}* {lineNumber}:\n\`\`\`{lang}\n{text}\n\`\`\
 function activate(context) {
 
 
-	let genRenderMap = () => {
-		let editor = vscode.window.activeTextEditor;
-		if (!Boolean(editor)) {
-			return null;
-		}
+	let genRenderMap = (editor) => {
 		let selText = editor.document.getText(editor.selection);
 		const dataMap = {
 			fileName: util.getRelFilenameOfActiveFile() || "Untitled",
@@ -31,13 +29,38 @@ function activate(context) {
 		return dataMap;
 	}
 
-	let cmdCopy = vscode.commands.registerCommand('copy-code-as-markdown.CopySelectionAsMarkdown', function () {
+	let getOutlinePath = async (editor, delimiter) => {
+		const outlineItems = await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', editor.document.uri);
+        if (!outlineItems) return null;
+        const outlinePath = outline.makeOutlineChainFromPos(outlineItems, editor.selection.active).map(({ name }) => name);
+        if (outlinePath.length === 0) {
+            void vscode.window.showInformationMessage('Outline path is empty');
+            return null;
+        }
+		return outlinePath.join(delimiter);
+	}
 
-		const renderMap = genRenderMap();
+	let cmdCopy = vscode.commands.registerCommand('copy-code-as-markdown.CopySelectionAsMarkdown', async function () {
+		
+		const editor = vscode.window.activeTextEditor;
+		if (!Boolean(editor)) {
+			return;
+		}
+
+		const config = vscode.workspace.getConfiguration('copyCodeAsMarkdown')
+
+		const renderMap = genRenderMap(editor);
 		if (!renderMap) {
 			return;
 		}
-		const config = vscode.workspace.getConfiguration('copyCodeAsMarkdown')
+
+		const delimiter = config.get('delimiter') || builtinDelimiter;
+
+		const outlinePath = await getOutlinePath(editor, delimiter);
+		if (outlinePath) {
+			renderMap.outlinePath = outlinePath;
+		}
+
 		let template = config.get('template') || config.get('defaultTemplate')
 		if (!template) {
 			template = builtinTemplate

--- a/extension.js
+++ b/extension.js
@@ -5,6 +5,7 @@ const util = require('./util');
 const outline = require('./outline');
 
 const builtinTemplate = `*{fileName}* {lineNumber}:\n\`\`\`{lang}\n{text}\n\`\`\``;
+const builtinPrefix = '> &squ; ';
 const builtinDelimiter = ' &raquo; ';
 
 
@@ -29,7 +30,7 @@ function activate(context) {
 		return dataMap;
 	}
 
-	let getOutlinePath = async (editor, delimiter) => {
+	let getOutlinePath = async (editor, options) => {
 		const outlineItems = await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', editor.document.uri);
         if (!outlineItems) return null;
         const outlinePath = outline.makeOutlineChainFromPos(outlineItems, editor.selection.active).map(({ name }) => name);
@@ -37,7 +38,7 @@ function activate(context) {
             void vscode.window.showInformationMessage('Outline path is empty');
             return null;
         }
-		return outlinePath.join(delimiter);
+		return options.prefix + outlinePath.join(options.delimiter);
 	}
 
 	let cmdCopy = vscode.commands.registerCommand('copy-code-as-markdown.CopySelectionAsMarkdown', async function () {
@@ -54,9 +55,10 @@ function activate(context) {
 			return;
 		}
 
-		const delimiter = config.get('delimiter') || builtinDelimiter;
+		const prefix = config.get('outlinePrefix') || builtinPrefix;
+		const delimiter = config.get('outlineDelimiter') || builtinDelimiter;
 
-		const outlinePath = await getOutlinePath(editor, delimiter);
+		const outlinePath = await getOutlinePath(editor, {prefix, delimiter});
 		if (outlinePath) {
 			renderMap.outlinePath = outlinePath;
 		}

--- a/outline.js
+++ b/outline.js
@@ -1,0 +1,52 @@
+const vscode = require('vscode');
+
+const findCurrentOutlineItem = (items, pos) => {
+    if (!items)
+        return;
+    let itemIndex = -1;
+    for (const [i, item] of items.entries()) {
+        if (item.children.length > 0) {
+            const foundItem = findCurrentOutlineItem(item.children, pos);
+            if (foundItem)
+                return foundItem;
+        }
+        if (item.range.contains(pos))
+            itemIndex = i;
+    }
+    if (itemIndex === -1)
+        return;
+    return items[itemIndex];
+};
+
+const findCurrentEditorOutlineItem = async () => {
+    const { activeTextEditor } = vscode.window;
+    if (!activeTextEditor)
+        return;
+    const outlineItems = await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', activeTextEditor.document.uri);
+    return findCurrentOutlineItem(outlineItems, activeTextEditor.selection.active);
+};
+
+const makeOutlineChainFromPos = (rootItems, pos) => {
+    const chain = [];
+    const findMe = (items) => {
+        let itemIndex = -1;
+        for (const [i, item] of items.entries()) {
+            if (item.range.contains(pos)) {
+                chain.push(item);
+                itemIndex = i;
+            }
+            if (item.children.length > 0) {
+                const foundItem = findMe(item.children);
+                if (foundItem)
+                    return foundItem;
+            }
+        }
+        if (itemIndex === -1)
+            return;
+        return items[itemIndex];
+    };
+    findMe(rootItems);
+    return chain;
+};
+
+module.exports = { findCurrentOutlineItem, findCurrentEditorOutlineItem, makeOutlineChainFromPos };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 						"only the markdown block",
 						"fileName, Line and markdown block"
 					],
-					"markdownDescription": "Available vars:\n\n+ `{fileName}`\n+ `{lineNumber}`\n+ `{lang}`\n+ `{text}`"
+					"markdownDescription": "Available vars:\n\n+ `{fileName}`\n+ `{lineNumber}`\n+ `{lang}`\n+ `{text}\n+ `{outlinePath}`"
 				},
 				"copyCodeAsMarkdown.usingTemplateName": {
 					"type": "string",
@@ -47,9 +47,14 @@
 						"default": "*{filename}* {lineNumber}:\n```{lang}\n{text}\n```",
 						"lineRange": "*{filename}* {lineNumber} - {lineNumberEnd}:\n```{lang}\n{text}\n```",
 						"onlyCode": "```{lang}\n{text}\n```",
-						"onlyPosition": "{filename}:{lineNumber}:{colNumber}"
+						"onlyPosition": "{filename}:{lineNumber}:{colNumber}",
+						"withOutline": "[{filename}#L{lineNumber}](/{filename}#L{lineNumber})\n>{outlinePath}\n```{lang}\n{text}\n```"
 					},
-					"markdownDescription": "Create your own template. Key is the template name, value is the template. Available vars:\n\n+ `{fileName}`\n+ `{lineNumber}`\n+ `{lineNumberEnd}`\n+ `{lang}`\n+ `{text}`"
+					"markdownDescription": "Create your own template. Key is the template name, value is the template. Available vars:\n\n+ `{fileName}`\n+ `{lineNumber}`\n+ `{lineNumberEnd}`\n+ `{lang}`\n+ `{text}\n+ `{outlinePath}`"
+				},
+				"copyCodeAsMarkdown.delimiter": {
+					"type": "string",
+					"default": " &raquo; "
 				}
 			}
 		},
@@ -70,10 +75,10 @@
 		"test": "node ./test/runTest.js"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.59.0",
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.2.2",
 		"@types/node": "14.x",
+		"@types/vscode": "^1.59.0",
 		"eslint": "^7.27.0",
 		"glob": "^7.1.7",
 		"mocha": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,15 @@
 						"lineRange": "*{filename}* {lineNumber} - {lineNumberEnd}:\n```{lang}\n{text}\n```",
 						"onlyCode": "```{lang}\n{text}\n```",
 						"onlyPosition": "{filename}:{lineNumber}:{colNumber}",
-						"withOutline": "[{filename}#L{lineNumber}](/{filename}#L{lineNumber})\n>{outlinePath}\n```{lang}\n{text}\n```"
+						"withOutline": "[{filename}#L{lineNumber}](/{filename}#L{lineNumber})\n{outlinePath}\n\n```{lang}\n{text}\n```"
 					},
 					"markdownDescription": "Create your own template. Key is the template name, value is the template. Available vars:\n\n+ `{fileName}`\n+ `{lineNumber}`\n+ `{lineNumberEnd}`\n+ `{lang}`\n+ `{text}\n+ `{outlinePath}`"
 				},
-				"copyCodeAsMarkdown.delimiter": {
+				"copyCodeAsMarkdown.outlinePrefix": {
+					"type": "string",
+					"default": "> &squ; "
+				},
+				"copyCodeAsMarkdown.outlineDelimiter": {
 					"type": "string",
 					"default": " &raquo; "
 				}


### PR DESCRIPTION
This extension is almost exactly what I needed. This PR adds the outline path—the same symbol hierarchy used in the editor breadcrumbs. It is helpful context for me when researching issues in a codebase.

I found the implementation to generate the path through this [comment](https://github.com/microsoft/vscode/issues/58678#issuecomment-1584522470), which directed me to [this script](https://github.com/zardoy/vscode-utils/blob/main/src/outline.ts#L26) in  
[zardoy/vscode-utils](https://github.com/zardoy/vscode-utils).

This change may be out of scope, so this is a draft PR.

**Sample template**

```
"[{filename}#L{lineNumber}](/{filename}#L{lineNumber})\n>{outlinePath}\n```{lang}\n{text}\n```"
```

**Sample output**

[alpha/beta/Foo.tsx#L5](alpha/beta/Foo.tsx#L5)
>Foo &raquo; useEffect() callback
```typescript
  useEffect(() => {
    if (isOpen) {
```